### PR TITLE
Prevent config values from regenerating

### DIFF
--- a/RankUpper-56/src/main/java/br/net/fabiozumbi12/RankUpper/RUCommands.java
+++ b/RankUpper-56/src/main/java/br/net/fabiozumbi12/RankUpper/RUCommands.java
@@ -480,7 +480,7 @@ public class RUCommands {
                     if (optVal >= key.getValue()) {
                         sender.sendMessage(RUUtil.toText(RankUpper.get().getLang().get("config.placeholderapi." + key.getKey() + ".ok").replace("{current}", optVal + "").replace("{target}", needed + "")));
                     } else {
-                        sender.sendMessage(RUUtil.toText(RankUpper.get().getLang().get("config.placeholderapi." + key.getKey()+ ".incomplete").replace("{current}", optVal + "").replace("{target}", needed + "")));
+                        sender.sendMessage(RUUtil.toText(RankUpper.get().getLang().get("config.placeholderapi." + key.getKey() + ".incomplete").replace("{current}", optVal + "").replace("{target}", needed + "")));
                     }
                 }
             }

--- a/RankUpper-56/src/main/java/br/net/fabiozumbi12/RankUpper/RUUtil.java
+++ b/RankUpper-56/src/main/java/br/net/fabiozumbi12/RankUpper/RUUtil.java
@@ -70,7 +70,14 @@ public class RUUtil {
 	public static double getPlaceholderValue(PlaceholderService papi, String placeholder, User p) {
 		Text text = papi.replacePlaceholders(placeholder, p, null);
 		if (text != null && !text.isEmpty() && text.toPlain() != null) {
-			return Double.parseDouble(text.toPlain());
+			try
+			{
+				return Double.parseDouble(text.toPlain());
+			}
+			catch(NumberFormatException e)
+			{
+				return 0;
+			}
 		}
 		return 0;
 	}

--- a/RankUpper-56/src/main/java/br/net/fabiozumbi12/RankUpper/config/RUConfig.java
+++ b/RankUpper-56/src/main/java/br/net/fabiozumbi12/RankUpper/config/RUConfig.java
@@ -42,7 +42,9 @@ public class RUConfig {
         try {
             Files.createDirectories(RankUpper.get().getConfigDir().toPath());
             File defConfig = new File(RankUpper.get().getConfigDir(), "rankupper.conf");
+            boolean newConfig = false;
             if (!defConfig.exists()) {
+                newConfig = true;
                 RankUpper.get().getLogger().log("Creating config file...");
                 defConfig.createNewFile();
             }
@@ -62,18 +64,20 @@ public class RUConfig {
                         120,
                         1000,
                         "member");
-                rgc.minecraft_statistic.put("MOB_KILLS", 100L);
-                rgc.minecraft_scoreboards.put("TeamBlue", 50L);
-                rgc.placeholder_api_requirements.put("%Pokedex%", 200L);
-                root.ranked_groups.put("group-example", rgc);
+                if (newConfig) {
+                    rgc.minecraft_statistic.put("MOB_KILLS", 100L);
+                    rgc.minecraft_scoreboards.put("TeamBlue", 50L);
+                    rgc.placeholder_api_requirements.put("%Pokedex%", 200L);
+                    root.ranked_groups.put("group-example", rgc);
+                }
             }
 
             for (RankedGroupsCategory group : root.ranked_groups.values()) {
-                if (group.minecraft_statistic.isEmpty())
+                if (newConfig && group.minecraft_statistic.isEmpty())
                     group.minecraft_statistic.put("MOB_KILLS", -1L);
-                if (group.minecraft_scoreboards.isEmpty())
+                if (newConfig && group.minecraft_scoreboards.isEmpty())
                     group.minecraft_scoreboards.put("TeamBlue", -1L);
-                if (group.placeholder_api_requirements.isEmpty())
+                if (newConfig && group.placeholder_api_requirements.isEmpty())
                     group.placeholder_api_requirements.put("%Pokedex%", -1L);
             }
 

--- a/RankUpper-56/src/main/resources/assets/rankupper/langEN-US.properties
+++ b/RankUpper-56/src/main/resources/assets/rankupper/langEN-US.properties
@@ -39,3 +39,5 @@ config.notsetgroup=&cThis group does not exist\! Check your config\!
 config.ok=&a(OK)
 config.setgroup=&aSuccessfully set group requirements\!
 config.time=&7-> Time
+config.placeholderapi.%Pokedex%.incomplete=&7-> Pokedex\: &c{current}% / {target}%
+config.placeholderapi.%Pokedex%.ok=&7-> Pokedex\: &a{current}% / {target}%


### PR DESCRIPTION
When editing the config, I noticed that fields I removed were being re-added during config reloads. This MR prevents the values from showing up again, unless you create a new config file.